### PR TITLE
Export classes needed to setup authentication headers

### DIFF
--- a/lib/flutter_graphql.dart
+++ b/lib/flutter_graphql.dart
@@ -9,6 +9,8 @@ export 'package:flutter_graphql/src/core/graphql_error.dart';
 
 export 'package:flutter_graphql/src/link/link.dart';
 export 'package:flutter_graphql/src/link/http/link_http.dart';
+export 'package:flutter_graphql/src/link/operation.dart';
+export 'package:flutter_graphql/src/link/fetch_result.dart';
 
 export 'package:flutter_graphql/src/cache/in_memory.dart';
 export 'package:flutter_graphql/src/cache/normalized_in_memory.dart';


### PR DESCRIPTION
#### Fixes / Enhancements

The README states that, in order to inject authentication headers, we need to import these files:

```dart
import 'package:flutter_graphql/flutter_graphql.dart';
import 'package:flutter_graphql/src/link/operation.dart';
import 'package:flutter_graphql/src/link/fetch_result.dart';
```

Importing files that are inside the `src` folder of a lib [is discouraged](https://dart-lang.github.io/linter/lints/implementation_imports.html).

This can be fixed by exporting those 2 files in the `flutter_graphql.dart`, as proposed here.
