### PR TITLE
Update path_provider to latest version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   meta: ^1.1.6
   http: ^0.12.0
   http_parser: ^3.1.3
-  path_provider: ^0.4.1
+  path_provider: ^0.5.0+1
   uuid: ^2.0.0
   sqflite: ^1.1.0
   graphql_parser: ^1.1.1


### PR DESCRIPTION
There is a conflict happening across some popular libraries in regards to this path_provider dependency. This is in regards to Android X compatibility and migration from deprecated Android Support Library

Describe the purpose of the pull request.

#### Fixes / Enhancements
- Updated path_provider dependency to the latest version

