### PR TITLE
Set loading to true on rebuild

### DIFF
--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -50,6 +50,11 @@ class ObservableQuery {
 
   void onListen() {
     if (options.fetchResults) {
+      controller.add(
+        QueryResult(
+          loading: true,
+        ),
+      );
       fetchResults();
     }
   }


### PR DESCRIPTION
This PR makes it possible for the loading boolean to be set to true when the Query widget is rebuilt.

#### Fixes / Enhancements

- Fixes #6 where `result.loading` within the QueryResult, it used to not set to `true` when the Query widget was rebuilt.