### PR TITLE
fixes function_typed_parameter_var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ ios/.generated/
 ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
 .flutter-plugins
+example/.flutter-plugins-dependencies
+example/ios/Flutter/flutter_export_environment.sh

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,7 +19,6 @@ linter:
     - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
     # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
@@ -78,7 +77,6 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -105,7 +103,6 @@ linter:
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -19,7 +19,6 @@ linter:
     - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
     # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
@@ -78,7 +77,6 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -105,7 +103,6 @@ linter:
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,3 +15,6 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+environment:
+  sdk: ">=2.10.0 <3.0.0"

--- a/lib/flutter_graphql.dart
+++ b/lib/flutter_graphql.dart
@@ -1,26 +1,21 @@
 library flutter_graphql;
 
-export 'package:flutter_graphql/src/graphql_client.dart';
-export 'package:flutter_graphql/src/socket_client.dart';
-
-export 'package:flutter_graphql/src/core/query_options.dart';
-export 'package:flutter_graphql/src/core/query_result.dart';
-export 'package:flutter_graphql/src/core/graphql_error.dart';
-
-export 'package:flutter_graphql/src/link/link.dart';
-export 'package:flutter_graphql/src/link/http/link_http.dart';
-export 'package:flutter_graphql/src/link/operation.dart';
-export 'package:flutter_graphql/src/link/fetch_result.dart';
-
 export 'package:flutter_graphql/src/cache/in_memory.dart';
 export 'package:flutter_graphql/src/cache/normalized_in_memory.dart';
-
+export 'package:flutter_graphql/src/core/graphql_error.dart';
+export 'package:flutter_graphql/src/core/query_options.dart';
+export 'package:flutter_graphql/src/core/query_result.dart';
+export 'package:flutter_graphql/src/graphql_client.dart';
+export 'package:flutter_graphql/src/link/fetch_result.dart';
+export 'package:flutter_graphql/src/link/http/link_http.dart';
+export 'package:flutter_graphql/src/link/link.dart';
+export 'package:flutter_graphql/src/link/operation.dart';
+export 'package:flutter_graphql/src/socket_client.dart';
 export 'package:flutter_graphql/src/websocket/messages.dart';
 export 'package:flutter_graphql/src/websocket/socket.dart';
-
-export 'package:flutter_graphql/src/widgets/graphql_provider.dart';
-export 'package:flutter_graphql/src/widgets/graphql_consumer.dart';
 export 'package:flutter_graphql/src/widgets/cache_provider.dart';
-export 'package:flutter_graphql/src/widgets/query.dart';
+export 'package:flutter_graphql/src/widgets/graphql_consumer.dart';
+export 'package:flutter_graphql/src/widgets/graphql_provider.dart';
 export 'package:flutter_graphql/src/widgets/mutation.dart';
+export 'package:flutter_graphql/src/widgets/query.dart';
 export 'package:flutter_graphql/src/widgets/subscription.dart';

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -1,5 +1,5 @@
 abstract class Cache {
-  Future<bool> remove(String key, bool cascade) async {}
+  Future<bool> remove(String key, bool cascade);
 
   dynamic read(String key) {}
 
@@ -13,5 +13,4 @@ abstract class Cache {
   void restore() {}
 
   void reset() {}
-
 }

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -1,5 +1,5 @@
 abstract class Cache {
-  Future<bool> remove(String key, bool cascade);
+  Future<bool>? remove(String key, bool cascade);
 
   dynamic read(String key) {}
 

--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -14,7 +14,7 @@ class InMemoryCache implements Cache {
   /// A directory to be used for storage.
   /// This is used for testing, on regular usage
   /// 'path_provider' will provide the storage directory.
-  final Directory customStorageDirectory;
+  final Directory? customStorageDirectory;
 
   HashMap<String, dynamic> _inMemoryCache = HashMap<String, dynamic>();
   bool _writingToStorage = false;
@@ -64,7 +64,7 @@ class InMemoryCache implements Cache {
   Future<String> get _localStoragePath async {
     if (customStorageDirectory != null) {
       // Used for testing
-      return customStorageDirectory.path;
+      return customStorageDirectory!.path;
     }
 
     final Directory directory = await getApplicationDocumentsDirectory();
@@ -139,7 +139,7 @@ class InMemoryCache implements Cache {
   }
 
   @override
-  Future<bool> remove(String key, bool cascade) {
+  Future<bool>? remove(String key, bool cascade) {
     // TODO: implement remove
     return null;
   }

--- a/lib/src/cache/normalized/record_field_json_adapter.dart
+++ b/lib/src/cache/normalized/record_field_json_adapter.dart
@@ -2,20 +2,15 @@ import 'dart:convert';
 import 'dart:core';
 
 class RecordFieldJsonAdapter {
-
   static RecordFieldJsonAdapter create() {
-    return new RecordFieldJsonAdapter();
-  }
-
-  RecordFieldJsonAdapter() {
+    return RecordFieldJsonAdapter();
   }
 
   dynamic toJson(Map<String, dynamic> fields) {
-    assert(fields != null);
     return json.encode(fields);
   }
 
-  Map<String, Object> from(dynamic jsonObj) {
+  Map<String, Object>? from(dynamic jsonObj) {
     assert(jsonObj != null);
     return json.decode(jsonObj);
   }

--- a/lib/src/cache/normalized/sql/sql-normalized-cache.dart
+++ b/lib/src/cache/normalized/sql/sql-normalized-cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter_graphql/src/cache/normalized/record_field_json_adapter.dart';
@@ -7,33 +8,33 @@ import 'package:sqflite/sqflite.dart';
 import '../../cache.dart';
 
 class SqlNormalizedCache implements Cache {
-
   SqlNormalizedCache(this.dbHelper, this.recordFieldAdapter) {
     dbHelper.open();
     database = dbHelper.db;
   }
-  
+
   static const String UPDATE_STATEMENT = '''UPDATE ${SqlHelper.TABLE_RECORDS} SET ${SqlHelper.COLUMN_KEY}=?, ${SqlHelper.COLUMN_RECORD}=? WHERE ${SqlHelper.COLUMN_KEY}=?''';
   static const String DELETE_STATEMENT = '''DELETE FROM ${SqlHelper.TABLE_RECORDS} WHERE ${SqlHelper.COLUMN_KEY}=?''';
   static const String DELETE_ALL_RECORD_STATEMENT = '''DELETE FROM ${SqlHelper.TABLE_RECORDS}''';
 
-  Database database;
+  Database? database;
   final SqlHelper dbHelper;
   final allColumns = [
-      SqlHelper.COLUMN_ID,
-      SqlHelper.COLUMN_KEY,
-      SqlHelper.COLUMN_RECORD];
+    SqlHelper.COLUMN_ID,
+    SqlHelper.COLUMN_KEY,
+    SqlHelper.COLUMN_RECORD
+  ];
   final RecordFieldJsonAdapter recordFieldAdapter;
   HashMap<String, dynamic> _inMemoryCache = HashMap<String, dynamic>();
 
   @override
-  Object read(String key) {
+  Object? read(String key) {
     // TODO: implement read
     return null;
   }
 
   Future<List<HashMap<String, dynamic>>> _readFromStorage() async {
-    List<HashMap<String, dynamic>> records = await database.query(SqlHelper.TABLE_RECORDS);
+    List<HashMap<String, dynamic>> records = await (database!.query(SqlHelper.TABLE_RECORDS) as FutureOr<List<HashMap<String, dynamic>>>);
     return records;
   }
 
@@ -54,14 +55,17 @@ class SqlNormalizedCache implements Cache {
 
   @override
   void write(String key, dynamic values) {
-    database.insert(SqlHelper.TABLE_RECORDS, values);
+    database!.insert(SqlHelper.TABLE_RECORDS, values);
   }
 
   @override
   Future<bool> remove(String key, bool cascade) async {
     assert(key != null);
-    final deletedObj = await database.delete(SqlHelper.TABLE_RECORDS, where: '${SqlHelper.COLUMN_KEY}=?', whereArgs: [key].toList());
+    final deletedObj = await database!.delete(SqlHelper.TABLE_RECORDS,
+        where: '${SqlHelper.COLUMN_KEY}=?',
+        whereArgs: [
+          key
+        ].toList());
     return true;
   }
-  
 }

--- a/lib/src/cache/normalized/sql/sql_helper.dart
+++ b/lib/src/cache/normalized/sql/sql_helper.dart
@@ -15,7 +15,7 @@ class SqlHelper {
   static const String IDX_RECORDS_KEY = 'idx_records_key';
   static const String CREATE_KEY_INDEX = '''CREATE INDEX $IDX_RECORDS_KEY ON $TABLE_RECORDS ($COLUMN_KEY)''';
 
-  Database db;
+  Database? db;
 
   Future open() async {
     final databasesPath = await getDatabasesPath();
@@ -27,7 +27,7 @@ class SqlHelper {
   }
 
   Future close() async {
-    await db.close();
+    await db!.close();
   }
   
 }

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -79,7 +79,7 @@ String? typenameDataIdFromObject(Object? object) {
   if (object is Map<String, Object> &&
       object.containsKey('__typename') &&
       object.containsKey('id')) {
-    return "${object['__typename']}/${object['id']}";
+    return '${object['__typename']}/${object['id']}';
   }
 
   return null;

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -1,28 +1,27 @@
-import 'package:meta/meta.dart';
-import 'package:flutter_graphql/src/utilities/traverse.dart';
 import 'package:flutter_graphql/src/cache/in_memory.dart';
-typedef String DataIdFromObject(Object node);
+import 'package:flutter_graphql/src/utilities/traverse.dart';
+typedef String? DataIdFromObject(Object? node);
 
 class NormalizationException implements Exception {
   NormalizationException(this.cause, this.overflowError, this.value);
 
   StackOverflowError overflowError;
   String cause;
-  Object value;
+  Object? value;
 
   String get message => cause;
 }
 
 class NormalizedInMemoryCache extends InMemoryCache {
   NormalizedInMemoryCache({
-    @required this.dataIdFromObject,
+    required this.dataIdFromObject,
     String prefix = '@cache/reference',
   }) : _prefix = prefix;
 
   DataIdFromObject dataIdFromObject;
   String _prefix;
 
-  Object _dereference(Object node) {
+  Object? _dereference(Object? node) {
     if (node is List && node.length == 2 && node[0] == _prefix) {
       return read(node[1]);
     }
@@ -36,7 +35,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
   */
   @override
   dynamic read(String key) {
-    final Object value = super.read(key);
+    final Object? value = super.read(key);
 
     try {
       return traverse(value, _dereference);
@@ -54,8 +53,8 @@ class NormalizedInMemoryCache extends InMemoryCache {
     }
   }
 
-  List<String> _normalize(Object node) {
-    final String dataId = dataIdFromObject(node);
+  List<String>? _normalize(Object? node) {
+    final String? dataId = dataIdFromObject(node);
 
     if (dataId != null) {
       write(dataId, node);
@@ -70,13 +69,13 @@ class NormalizedInMemoryCache extends InMemoryCache {
     replacing them with references
   */
   @override
-  void write(String key, Object value) {
-    final Object normalized = traverseValues(value, _normalize);
+  void write(String key, Object? value) {
+    final Object normalized = traverseValues(value as Map<String, Object>, _normalize);
     super.write(key, normalized);
   }
 }
 
-String typenameDataIdFromObject(Object object) {
+String? typenameDataIdFromObject(Object? object) {
   if (object is Map<String, Object> &&
       object.containsKey('__typename') &&
       object.containsKey('id')) {

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_graphql/src/cache/in_memory.dart';
 import 'package:flutter_graphql/src/utilities/traverse.dart';
+
 typedef String? DataIdFromObject(Object? node);
 
 class NormalizationException implements Exception {
@@ -58,7 +59,10 @@ class NormalizedInMemoryCache extends InMemoryCache {
 
     if (dataId != null) {
       write(dataId, node);
-      return <String>[_prefix, dataId];
+      return <String>[
+        _prefix,
+        dataId
+      ];
     }
 
     return null;
@@ -70,15 +74,13 @@ class NormalizedInMemoryCache extends InMemoryCache {
   */
   @override
   void write(String key, Object? value) {
-    final Object normalized = traverseValues(value as Map<String, Object>, _normalize);
+    final Object normalized = traverseValues(Map.castFrom<String, dynamic, String, Object>(value as Map<String, dynamic>), _normalize);
     super.write(key, normalized);
   }
 }
 
 String? typenameDataIdFromObject(Object? object) {
-  if (object is Map<String, Object> &&
-      object.containsKey('__typename') &&
-      object.containsKey('id')) {
+  if (object is Map<String, Object> && object.containsKey('__typename') && object.containsKey('id')) {
     return '${object['__typename']}/${object['id']}';
   }
 

--- a/lib/src/core/graphql_error.dart
+++ b/lib/src/core/graphql_error.dart
@@ -6,10 +6,10 @@ class Location {
         column = data['column'];
 
   /// The line of the error in the query.
-  final int line;
+  final int? line;
 
   /// The column of the error in the query.
-  final int column;
+  final int? column;
 
   @override
   String toString() => '{ line: $line, column: $column }';
@@ -42,18 +42,18 @@ class GraphQLError {
   final dynamic data;
 
   /// The message of the error.
-  final String message;
+  final String? message;
 
   /// Locations where the error appear.
-  final List<Location> locations;
+  final List<Location>? locations;
 
   /// The path of the field in error.
-  final List<dynamic> path;
+  final List<dynamic>? path;
 
   /// Custom error data returned by your GraphQL API server
-  final Map<String, dynamic> extensions;
+  final Map<String, dynamic>? extensions;
 
   @override
   String toString() =>
-      '$message: ${locations is List ? locations.map((Location l) => '[${l.toString()}]').join('') : "Undefined location"}';
+      '$message: ${locations is List ? locations!.map((Location l) => '[${l.toString()}]').join('') : "Undefined location"}';
 }

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -4,7 +4,6 @@ import 'package:flutter_graphql/flutter_graphql.dart';
 import 'package:flutter_graphql/src/core/query_manager.dart';
 import 'package:flutter_graphql/src/core/query_result.dart';
 import 'package:flutter_graphql/src/scheduler/scheduler.dart';
-import 'package:meta/meta.dart';
 
 
 typedef void OnData(QueryResult? result);

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -119,8 +119,7 @@ class QueryManager {
       ).first;
 
       // save the data from fetchResult to the cache
-      if (fetchResult.data != null &&
-          options.fetchPolicy != FetchPolicy.noCache) {
+      if (fetchResult.data != null && options.fetchPolicy != FetchPolicy.noCache) {
         cache.write(
           operation.toKey(),
           fetchResult.data,
@@ -138,10 +137,14 @@ class QueryManager {
 
       queryResult = _mapFetchResultToQueryResult(fetchResult);
     } catch (error) {
-      // TODO some dart errors break this
-      final GraphQLError graphQLError = GraphQLError(
-        message: error.message,
-      );
+      GraphQLError graphQLError;
+
+      try {
+        // TODO some dart errors break this
+        graphQLError = GraphQLError(message: error.message);
+      } catch (e) {
+        graphQLError = GraphQLError(message: 'An error has ocurred');
+      }
 
       if (queryResult != null) {
         queryResult.addError(graphQLError);

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -1,26 +1,20 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
-
-import 'package:flutter_graphql/src/core/query_options.dart';
-import 'package:flutter_graphql/src/core/query_result.dart';
+import 'package:flutter_graphql/src/cache/cache.dart';
 import 'package:flutter_graphql/src/core/graphql_error.dart';
 import 'package:flutter_graphql/src/core/observable_query.dart';
-
-import 'package:flutter_graphql/src/scheduler/scheduler.dart';
-
+import 'package:flutter_graphql/src/core/query_options.dart';
+import 'package:flutter_graphql/src/core/query_result.dart';
+import 'package:flutter_graphql/src/link/fetch_result.dart';
 import 'package:flutter_graphql/src/link/link.dart';
 import 'package:flutter_graphql/src/link/operation.dart';
-import 'package:flutter_graphql/src/link/fetch_result.dart';
-
-import 'package:flutter_graphql/src/cache/cache.dart';
-
+import 'package:flutter_graphql/src/scheduler/scheduler.dart';
 import 'package:flutter_graphql/src/utilities/get_from_ast.dart';
 
 class QueryManager {
   QueryManager({
-    @required this.link,
-    @required this.cache,
+    required this.link,
+    required this.cache,
   }) {
     scheduler = QueryScheduler(
       queryManager: this,
@@ -30,7 +24,7 @@ class QueryManager {
   final Link link;
   final Cache cache;
 
-  QueryScheduler scheduler;
+  QueryScheduler? scheduler;
   int idCounter = 1;
   Map<String, ObservableQuery> queries = <String, ObservableQuery>{};
 
@@ -51,22 +45,22 @@ class QueryManager {
     return observableQuery;
   }
 
-  Future<QueryResult> query(QueryOptions options) {
+  Future<QueryResult?> query(QueryOptions options) {
     return fetchQuery('0', options);
   }
 
-  Future<QueryResult> mutate(MutationOptions options) {
+  Future<QueryResult?> mutate(MutationOptions options) {
     return fetchQuery('0', options);
   }
 
-  Future<QueryResult> fetchQuery(
+  Future<QueryResult?> fetchQuery(
     String queryId,
     BaseOptions options,
   ) async {
-    final ObservableQuery observableQuery = getQuery(queryId);
+    final ObservableQuery? observableQuery = getQuery(queryId);
     // XXX there is a bug in the `graphql_parser` package, where this result might be
     // null event though the operation name is present in the document
-    final String operationName = getOperationName(options.document);
+    final String? operationName = getOperationName(options.document);
     // create a new operation to fetch
     final Operation operation = Operation(
       document: options.document,
@@ -75,11 +69,11 @@ class QueryManager {
     );
 
     FetchResult fetchResult;
-    QueryResult queryResult;
+    QueryResult? queryResult;
 
     try {
       if (options.context != null) {
-        operation.setContext(options.context);
+        operation.setContext(options.context!);
       }
 
       if (options.fetchPolicy == FetchPolicy.cacheFirst ||
@@ -141,7 +135,7 @@ class QueryManager {
 
       try {
         // TODO some dart errors break this
-        graphQLError = GraphQLError(message: error.message);
+        graphQLError = GraphQLError(message: error.toString());
       } catch (e) {
         graphQLError = GraphQLError(message: 'An error has ocurred');
       }
@@ -164,7 +158,7 @@ class QueryManager {
     return queryResult;
   }
 
-  ObservableQuery getQuery(String queryId) {
+  ObservableQuery? getQuery(String queryId) {
     if (queries.containsKey(queryId)) {
       return queries[queryId];
     }
@@ -192,10 +186,10 @@ class QueryManager {
   }
 
   QueryResult _mapFetchResultToQueryResult(FetchResult fetchResult) {
-    List<GraphQLError> errors;
+    List<GraphQLError>? errors;
 
     if (fetchResult.errors != null) {
-      errors = List<GraphQLError>.from(fetchResult.errors.map<GraphQLError>(
+      errors = List<GraphQLError>.from(fetchResult.errors!.map<GraphQLError>(
         (dynamic rawError) => GraphQLError.fromJSON(rawError),
       ));
     }

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_graphql/src/graphql_client.dart';
-import 'package:meta/meta.dart';
 
 /// [FetchPolicy] determines where the client may return a result from. The options are:
 /// - cacheFirst (default): return result from cache. Only fetch from network if cached result is not available.

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -28,7 +28,7 @@ enum ErrorPolicy {
 /// Base options.
 class BaseOptions {
   BaseOptions({
-    @required this.document,
+    required this.document,
     this.variables,
     this.fetchPolicy,
     this.errorPolicy,
@@ -41,30 +41,30 @@ class BaseOptions {
 
   /// A map going from variable name to variable value, where the variables are used
   /// within the GraphQL query.
-  Map<String, dynamic> variables;
+  Map<String, dynamic>? variables;
 
   /// Specifies the [FetchPolicy] to be used.
-  FetchPolicy fetchPolicy;
+  FetchPolicy? fetchPolicy;
 
   /// Specifies the [ErrorPolicy] to be used.
-  ErrorPolicy errorPolicy;
+  ErrorPolicy? errorPolicy;
 
   /// Context to be passed to link execution chain.
-  Map<String, dynamic> context;
+  Map<String, dynamic>? context;
 
-  GraphQLClient client;
+  GraphQLClient? client;
 }
 
 /// Query options.
 class QueryOptions extends BaseOptions {
   QueryOptions({
-    @required String document,
-    Map<String, dynamic> variables,
-    FetchPolicy fetchPolicy = FetchPolicy.cacheFirst,
-    ErrorPolicy errorPolicy = ErrorPolicy.none,
+    required String document,
+    Map<String, dynamic>? variables,
+    FetchPolicy? fetchPolicy = FetchPolicy.cacheFirst,
+    ErrorPolicy? errorPolicy = ErrorPolicy.none,
     this.pollInterval,
-    Map<String, dynamic> context,
-    GraphQLClient client,
+    Map<String, dynamic>? context,
+    GraphQLClient? client,
   }) : super(
           document: document,
           variables: variables,
@@ -76,18 +76,18 @@ class QueryOptions extends BaseOptions {
 
   /// The time interval (in milliseconds) on which this query should be
   /// refetched from the server.
-  int pollInterval;
+  int? pollInterval;
 }
 
 /// Mutation options
 class MutationOptions extends BaseOptions {
   MutationOptions({
-    @required String document,
-    Map<String, dynamic> variables,
+    required String document,
+    Map<String, dynamic>? variables,
     FetchPolicy fetchPolicy = FetchPolicy.networkOnly,
     ErrorPolicy errorPolicy = ErrorPolicy.none,
-    Map<String, dynamic> context,
-    GraphQLClient client
+    Map<String, dynamic>? context,
+    GraphQLClient? client
   }) : super(
           document: document,
           variables: variables,
@@ -101,14 +101,14 @@ class MutationOptions extends BaseOptions {
 // ObservableQuery options
 class WatchQueryOptions extends QueryOptions {
   WatchQueryOptions({
-    @required String document,
-    Map<String, dynamic> variables,
-    FetchPolicy fetchPolicy = FetchPolicy.cacheAndNetwork,
-    ErrorPolicy errorPolicy = ErrorPolicy.none,
-    int pollInterval,
+    required String document,
+    Map<String, dynamic>? variables,
+    FetchPolicy? fetchPolicy = FetchPolicy.cacheAndNetwork,
+    ErrorPolicy? errorPolicy = ErrorPolicy.none,
+    int? pollInterval,
     this.fetchResults,
-    Map<String, dynamic> context,
-    GraphQLClient client,
+    Map<String, dynamic>? context,
+    GraphQLClient? client,
   }) : super(
           document: document,
           variables: variables,
@@ -120,7 +120,7 @@ class WatchQueryOptions extends QueryOptions {
         );
 
   /// Whether or not to fetch result.
-  bool fetchResults;
+  bool? fetchResults;
 
   /// Checks if the [WatchQueryOptions] in this class are equal to some given options.
   bool areEqualTo(WatchQueryOptions otherOptions) {
@@ -157,8 +157,8 @@ class WatchQueryOptions extends QueryOptions {
   }
 
   bool _areDifferentVariables(
-    Map<String, dynamic> a,
-    Map<String, dynamic> b,
+    Map<String, dynamic>? a,
+    Map<String, dynamic>? b,
   ) {
     if (a == null && b == null) {
       return false;

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -10,21 +10,21 @@ class QueryResult {
 
   /// List<dynamic> or Map<String, dynamic>
   dynamic data;
-  List<GraphQLError> errors;
-  bool loading;
-  bool stale;
+  List<GraphQLError>? errors;
+  bool? loading;
+  bool? stale;
 
   bool get hasErrors {
     if (errors == null) {
       return false;
     }
 
-    return errors.isNotEmpty;
+    return errors!.isNotEmpty;
   }
 
   void addError(GraphQLError graphQLError) {
     if (errors != null) {
-      errors.add(graphQLError);
+      errors!.add(graphQLError);
     } else {
       errors = <GraphQLError>[graphQLError];
     }

--- a/lib/src/graphql_client.dart
+++ b/lib/src/graphql_client.dart
@@ -1,14 +1,11 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
-
-import 'package:flutter_graphql/src/core/query_manager.dart';
-import 'package:flutter_graphql/src/core/query_result.dart';
-import 'package:flutter_graphql/src/core/observable_query.dart';
-import 'package:flutter_graphql/src/core/query_options.dart';
-
-import 'package:flutter_graphql/src/link/link.dart';
 import 'package:flutter_graphql/src/cache/cache.dart';
+import 'package:flutter_graphql/src/core/observable_query.dart';
+import 'package:flutter_graphql/src/core/query_manager.dart';
+import 'package:flutter_graphql/src/core/query_options.dart';
+import 'package:flutter_graphql/src/core/query_result.dart';
+import 'package:flutter_graphql/src/link/link.dart';
 
 /// The link is a [Link] over which GraphQL documents will be resolved into a [FetchResult].
 /// The cache is the initial [Cache] to use in the data store.
@@ -19,12 +16,12 @@ class GraphQLClient {
   /// The initial [Cache] to use in the data store.
   final Cache cache;
 
-  QueryManager queryManager;
+  late QueryManager queryManager;
 
   /// Constructs a [GraphQLClient] given a [Link] and a [Cache].
   GraphQLClient({
-    @required this.link,
-    @required this.cache,
+    required this.link,
+    required this.cache,
   }) {
     queryManager = QueryManager(
       link: link,
@@ -40,13 +37,13 @@ class GraphQLClient {
 
   /// This resolves a single query according to the [QueryOptions] specified and
   /// returns a [Future] which resolves with the [QueryResult] or throws an [Exception].
-  Future<QueryResult> query(QueryOptions options) {
+  Future<QueryResult?> query(QueryOptions options) {
     return queryManager.query(options);
   }
 
   /// This resolves a single mutation according to the [MutationOptions] specified and
   /// returns a [Future] which resolves with the [QueryResult] or throws an [Exception].
-  Future<QueryResult> mutate(MutationOptions options) {
+  Future<QueryResult?> mutate(MutationOptions options) {
     return queryManager.mutate(options);
   }
 

--- a/lib/src/link/auth/auth_link.dart
+++ b/lib/src/link/auth/auth_link.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
+import 'package:flutter_graphql/src/link/fetch_result.dart';
 import 'package:flutter_graphql/src/link/link.dart';
 import 'package:flutter_graphql/src/link/operation.dart';
-import 'package:flutter_graphql/src/link/fetch_result.dart';
 
 typedef GetToken = Future<String> Function();
 
@@ -10,21 +10,24 @@ class AuthLink extends Link {
   AuthLink({
     this.getToken,
   }) : super(
-          request: (Operation operation, [NextLink forward]) {
-            StreamController<FetchResult> controller;
+          request: (Operation? operation, [NextLink? forward]) {
+            late StreamController<FetchResult> controller;
 
             Future<void> onListen() async {
               try {
-                final String token = await getToken();
+                final String token = await getToken!();
 
-                operation.setContext(<String, Map<String, String>>{
-                  'headers': <String, String>{'Authorization': token}
+                operation?.setContext(<String, Map<String, String>>{
+                  'headers': <String, String>{
+                    'Authorization': token
+                  }
                 });
               } catch (error) {
                 controller.addError(error);
               }
-
-              await controller.addStream(forward(operation));
+              if (forward != null && operation != null) {
+                await controller.addStream(forward(operation));
+              }
               await controller.close();
             }
 
@@ -34,5 +37,5 @@ class AuthLink extends Link {
           },
         );
 
-  GetToken getToken;
+  GetToken? getToken;
 }

--- a/lib/src/link/fetch_result.dart
+++ b/lib/src/link/fetch_result.dart
@@ -6,10 +6,10 @@ class FetchResult {
     this.context,
   });
 
-  List<dynamic> errors;
+  List<dynamic>? errors;
 
   /// List<dynamic> or Map<String, dynamic>
   dynamic data;
-  Map<String, dynamic> extensions;
-  Map<String, dynamic> context;
+  Map<String, dynamic>? extensions;
+  Map<String, dynamic>? context;
 }

--- a/lib/src/link/http/http_config.dart
+++ b/lib/src/link/http/http_config.dart
@@ -4,8 +4,8 @@ class HttpQueryOptions {
     this.includeExtensions,
   });
 
-  bool includeQuery;
-  bool includeExtensions;
+  bool? includeQuery;
+  bool? includeExtensions;
 
   void addAll(HttpQueryOptions options) {
     if (options.includeQuery != null) {
@@ -26,10 +26,10 @@ class HttpConfig {
     this.headers,
   });
 
-  HttpQueryOptions http;
-  Map<String, dynamic> options;
-  Map<String, dynamic> credentials;
-  Map<String, String> headers;
+  HttpQueryOptions? http;
+  Map<String, dynamic>? options;
+  Map<String, dynamic>? credentials;
+  Map<String, String>? headers;
 }
 
 class HttpOptionsAndBody {
@@ -38,6 +38,6 @@ class HttpOptionsAndBody {
     this.body,
   });
 
-  final Map<String, dynamic> options;
-  final String body;
+  final Map<String, dynamic>? options;
+  final String? body;
 }

--- a/lib/src/link/http/http_config.dart
+++ b/lib/src/link/http/http_config.dart
@@ -29,7 +29,7 @@ class HttpConfig {
   HttpQueryOptions? http;
   Map<String, dynamic>? options;
   Map<String, dynamic>? credentials;
-  Map<String, String>? headers;
+  Map<String, dynamic>? headers;
 }
 
 class HttpOptionsAndBody {

--- a/lib/src/link/http/http_config.dart
+++ b/lib/src/link/http/http_config.dart
@@ -29,7 +29,7 @@ class HttpConfig {
   HttpQueryOptions? http;
   Map<String, dynamic>? options;
   Map<String, dynamic>? credentials;
-  Map<String, dynamic>? headers;
+  Map<String, String>? headers;
 }
 
 class HttpOptionsAndBody {

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -14,7 +14,7 @@ class HttpLink extends Link {
     required String uri,
     bool? includeExtensions,
     Client? fetch,
-    Map<String, String>? headers,
+    Map<String, dynamic>? headers,
     Map<String, dynamic>? credentials,
     Map<String, dynamic>? fetchOptions,
   }) : super(

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -47,7 +47,7 @@ class HttpLink extends Link {
                 ),
                 options: context['fetchOptions'],
                 credentials: context['credentials'],
-                headers: context['headers'],
+                headers: (context['headers'] as Map<String, dynamic>).map((String key, dynamic value) => MapEntry<String, String>(key, value ?? '')),
               );
             }
 

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -69,7 +69,7 @@ class HttpLink extends Link {
               try {
                 // TODO: support multiple http methods
                 response = await fetcher.post(
-                  uri,
+                  Uri.parse(uri),
                   headers: httpHeaders,
                   body: httpOptionsAndBody.body,
                 );

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -14,7 +14,7 @@ class HttpLink extends Link {
     required String uri,
     bool? includeExtensions,
     Client? fetch,
-    Map<String, dynamic>? headers,
+    Map<String, String>? headers,
     Map<String, dynamic>? credentials,
     Map<String, dynamic>? fetchOptions,
   }) : super(
@@ -140,16 +140,18 @@ HttpOptionsAndBody _selectHttpOptionsAndBody(
   // headers
 
   // initialze with fallback headers
-  options['headers'].addAll(fallbackConfig.headers);
+  if (fallbackConfig.headers != null) {
+    (options['headers'] as Map<String, String>).addAll(fallbackConfig.headers!);
+  }
 
   // inject the configured headers
   if (linkConfig.headers != null) {
-    options['headers'].addAll(linkConfig.headers);
+    (options['headers'] as Map<String, String>).addAll(linkConfig.headers!);
   }
 
   // inject the context headers
   if (contextConfig.headers != null) {
-    options['headers'].addAll(contextConfig.headers);
+    (options['headers'] as Map<String, String>).addAll(contextConfig.headers!);
   }
 
   // credentials

--- a/lib/src/link/link.dart
+++ b/lib/src/link/link.dart
@@ -8,22 +8,25 @@ typedef NextLink = Stream<FetchResult> Function(
 );
 
 typedef RequestHandler = Stream<FetchResult> Function(
-  Operation operation, [
-  NextLink forward,
+  Operation? operation, [
+  NextLink? forward,
 ]);
 
 Link _concat(
   Link first,
   Link second,
 ) {
-  return Link(request: (
-    Operation operation, [
-    NextLink forward,
-  ]) {
-    return first.request(operation, (Operation op) {
-      return second.request(op, forward);
-    });
-  });
+  return Link(
+      request: first.request == null || second.request == null
+          ? null
+          : (
+              Operation? operation, [
+              NextLink? forward,
+            ]) {
+              return first.request!(operation, (Operation op) {
+                return second.request!(op, forward);
+              });
+            });
 }
 
 class Link {
@@ -31,7 +34,7 @@ class Link {
     this.request,
   });
 
-  final RequestHandler request;
+  final RequestHandler? request;
 
   Link concat(Link next) {
     return _concat(this, next);
@@ -39,8 +42,8 @@ class Link {
 }
 
 Stream<FetchResult> execute({
-  Link link,
-  Operation operation,
+  required Link link,
+  Operation? operation,
 }) {
-  return link.request(operation);
+  return link.request!(operation);
 }

--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -8,10 +8,10 @@ class Operation {
     this.extensions,
   });
 
-  final String document;
-  final Map<String, dynamic> variables;
-  final String operationName;
-  final Map<String, dynamic> extensions;
+  final String? document;
+  final Map<String, dynamic>? variables;
+  final String? operationName;
+  final Map<String, dynamic>? extensions;
 
   final Map<String, dynamic> _context = <String, dynamic>{};
 

--- a/lib/src/link/web_socket/link_web_socket.dart
+++ b/lib/src/link/web_socket/link_web_socket.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_graphql/src/link/link.dart';
 
 class WebSocketLink extends Link {
-  RequestHandler subscriptionClient;
+  RequestHandler? subscriptionClient;
 
   // TODO: implement https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-ws/src/webSocketLink.ts
 }

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -9,7 +9,7 @@ class QueryScheduler {
     this.queryManager,
   });
 
-  QueryManager queryManager;
+  QueryManager? queryManager;
 
   /// Map going from query ids to the [WatchQueryOptions] associated with those queries.
   Map<String, WatchQueryOptions> registeredQueries =
@@ -26,7 +26,7 @@ class QueryScheduler {
     Timer timer,
     Duration interval,
   ) {
-    intervalQueries[interval].retainWhere(
+    intervalQueries[interval]!.retainWhere(
       (String queryId) {
         // If ObservableQuery can't be found from registeredQueries or if it has a
         // different interval, it means that this queryId is no longer registered
@@ -41,7 +41,7 @@ class QueryScheduler {
         }
 
         final Duration pollInterval =
-            Duration(seconds: registeredQueries[queryId].pollInterval);
+            Duration(seconds: registeredQueries[queryId]!.pollInterval!);
 
         return registeredQueries.containsKey(queryId) &&
             pollInterval == interval;
@@ -49,7 +49,7 @@ class QueryScheduler {
     );
 
     // if no queries on the interval clean up
-    if (intervalQueries[interval].isEmpty) {
+    if (intervalQueries[interval]!.isEmpty) {
       intervalQueries.remove(interval);
       _pollingTimers.remove(interval);
       timer.cancel();
@@ -57,9 +57,9 @@ class QueryScheduler {
     }
 
     // fetch each query on the interval
-    for (String queryId in intervalQueries[interval]) {
-      final WatchQueryOptions options = registeredQueries[queryId];
-      queryManager.fetchQuery(queryId, options);
+    for (String queryId in intervalQueries[interval]!) {
+      final WatchQueryOptions options = registeredQueries[queryId]!;
+      queryManager!.fetchQuery(queryId, options);
     }
   }
 
@@ -70,11 +70,11 @@ class QueryScheduler {
     registeredQueries[queryId] = options;
 
     final Duration interval = Duration(
-      seconds: options.pollInterval,
+      seconds: options.pollInterval!,
     );
 
     if (intervalQueries.containsKey(interval)) {
-      intervalQueries[interval].add(queryId);
+      intervalQueries[interval]!.add(queryId);
     } else {
       intervalQueries[interval] = <String>[queryId];
 

--- a/lib/src/socket_client.dart
+++ b/lib/src/socket_client.dart
@@ -1,16 +1,15 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter_graphql/flutter_graphql.dart';
 import 'package:uuid/uuid.dart';
 
-import 'package:flutter_graphql/flutter_graphql.dart';
-
-SocketClient socketClient;
+late SocketClient socketClient;
 
 class SocketClient {
   final Uuid _uuid = Uuid();
   final GraphQLSocket _socket;
-  static Map<String, String> _initPayload;
+  static Map<String, String>? _initPayload;
 
   SocketClient(this._socket) {
     _socket.connectionAck.listen(print);
@@ -27,7 +26,7 @@ class SocketClient {
     final Map<String, String> headers = const <String, String>{
       'content-type': 'application/json',
     },
-    final Map<String, String> initPayload,
+    final Map<String, String>? initPayload,
   }) async {
     _initPayload = initPayload;
 

--- a/lib/src/utilities/get_from_ast.dart
+++ b/lib/src/utilities/get_from_ast.dart
@@ -1,6 +1,7 @@
-import 'package:graphql_parser/graphql_parser.dart';
+import 'package:collection/collection.dart' show IterableExtension;
+import 'package:graphql_parser2/graphql_parser2.dart';
 
-String getOperationName(String rawDoc) {
+String? getOperationName(String rawDoc) {
   final List<Token> tokens = scan(rawDoc);
   final Parser parser = Parser(tokens);
 
@@ -13,10 +14,9 @@ String getOperationName(String rawDoc) {
   final DocumentContext doc = parser.parseDocument();
 
   if (doc.definitions != null && doc.definitions.isNotEmpty) {
-    final OperationDefinitionContext definition = doc.definitions.lastWhere(
+    final OperationDefinitionContext? definition = doc.definitions.lastWhereOrNull(
       (DefinitionContext context) => context is OperationDefinitionContext,
-      orElse: () => null,
-    );
+    ) as OperationDefinitionContext?;
 
     if (definition != null) {
       if (definition.name != null) {

--- a/lib/src/utilities/helpers.dart
+++ b/lib/src/utilities/helpers.dart
@@ -1,3 +1,3 @@
-bool notNull(Object any) {
+bool notNull(Object? any) {
   return any != null;
 }

--- a/lib/src/utilities/traverse.dart
+++ b/lib/src/utilities/traverse.dart
@@ -1,11 +1,11 @@
 typedef Object? Transform(Object? node);
 
 Map<String, Object?> traverseValues(
-  Map<String, Object> node,
+  Map<String, Object?> node,
   Transform transform,
 ) {
   return node.map<String, Object?>(
-    (String key, Object value) => MapEntry<String, Object?>(
+    (String key, Object? value) => MapEntry<String, Object?>(
           key,
           traverse(value, transform),
         ),
@@ -19,14 +19,11 @@ Object? traverse(Object? node, Transform transform) {
   if (transformed != null) {
     return transformed;
   }
-
-  if (node is List<Object>) {
-    return node
-        .map<Object?>((Object node) => traverse(node, transform))
-        .toList();
+  if (node is List) {
+    return node.map<Object?>((dynamic node) => traverse(node, transform)).toList();
   }
-  if (node is Map<String, Object>) {
-    return traverseValues(node, transform);
+  if (node is Map) {
+    return traverseValues(node as Map<String, Object?>, transform);
   }
   return node;
 }

--- a/lib/src/utilities/traverse.dart
+++ b/lib/src/utilities/traverse.dart
@@ -1,11 +1,11 @@
-typedef Object Transform(Object node);
+typedef Object? Transform(Object? node);
 
-Map<String, Object> traverseValues(
+Map<String, Object?> traverseValues(
   Map<String, Object> node,
   Transform transform,
 ) {
-  return node.map<String, Object>(
-    (String key, Object value) => MapEntry<String, Object>(
+  return node.map<String, Object?>(
+    (String key, Object value) => MapEntry<String, Object?>(
           key,
           traverse(value, transform),
         ),
@@ -14,15 +14,15 @@ Map<String, Object> traverseValues(
 
 // Attempts to apply the transform to every leaf of the data structure recursively.
 // Stops recursing when a node is transformed (returns non-null)
-Object traverse(Object node, Transform transform) {
-  final Object transformed = transform(node);
+Object? traverse(Object? node, Transform transform) {
+  final Object? transformed = transform(node);
   if (transformed != null) {
     return transformed;
   }
 
   if (node is List<Object>) {
     return node
-        .map<Object>((Object node) => traverse(node, transform))
+        .map<Object?>((Object node) => traverse(node, transform))
         .toList();
   }
   if (node is Map<String, Object>) {

--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -50,7 +50,7 @@ abstract class GraphQLSocketMessage extends JsonSerializable {
 class InitOperation extends GraphQLSocketMessage {
   InitOperation(this.payload) : super(MessageTypes.GQL_CONNECTION_INIT);
 
-  final Map<String, String> payload;
+  final Map<String, String>? payload;
 
   @override
   dynamic toJson() {

--- a/lib/src/websocket/socket.dart
+++ b/lib/src/websocket/socket.dart
@@ -9,10 +9,10 @@ import '../../flutter_graphql.dart';
 class GraphQLSocket {
   GraphQLSocket(this._socket) {
     _socket
-        .map<Map<String, dynamic>>((dynamic message) => json.decode(message))
+        .map<Map<String, dynamic>?>((dynamic message) => json.decode(message))
         .listen(
-      (Map<String, dynamic> message) {
-        final String type = message['type'] ?? 'unknown';
+      (Map<String, dynamic>? message) {
+        final String type = message!['type'] ?? 'unknown';
         final dynamic payload = message['payload'] ?? <String, dynamic>{};
         final String id = message['id'] ?? 'none';
 

--- a/lib/src/widgets/cache_provider.dart
+++ b/lib/src/widgets/cache_provider.dart
@@ -57,7 +57,7 @@ class _CacheProviderState extends State<CacheProvider>
         client.cache?.save();
         break;
 
-      case AppLifecycleState.suspending:
+      case AppLifecycleState.detached:
         break;
 
       case AppLifecycleState.resumed:

--- a/lib/src/widgets/cache_provider.dart
+++ b/lib/src/widgets/cache_provider.dart
@@ -5,8 +5,8 @@ import 'package:flutter_graphql/src/widgets/graphql_provider.dart';
 
 class CacheProvider extends StatefulWidget {
   const CacheProvider({
-    final Key key,
-    @required this.child,
+    final Key? key,
+    required this.child,
   }) : super(key: key);
 
   final Widget child;
@@ -17,13 +17,13 @@ class CacheProvider extends StatefulWidget {
 
 class _CacheProviderState extends State<CacheProvider>
     with WidgetsBindingObserver {
-  GraphQLClient client;
+  GraphQLClient? client;
 
   @override
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance!.addObserver(this);
   }
 
   @override
@@ -32,7 +32,7 @@ class _CacheProviderState extends State<CacheProvider>
     client = GraphQLProvider.of(context).value;
     assert(client != null);
 
-    client.cache?.restore();
+    client!.cache.restore();
 
     super.didChangeDependencies();
   }
@@ -41,7 +41,7 @@ class _CacheProviderState extends State<CacheProvider>
   void dispose() {
     super.dispose();
 
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance!.removeObserver(this);
   }
 
   @override
@@ -50,18 +50,18 @@ class _CacheProviderState extends State<CacheProvider>
 
     switch (state) {
       case AppLifecycleState.inactive:
-        client.cache?.save();
+        client!.cache.save();
         break;
 
       case AppLifecycleState.paused:
-        client.cache?.save();
+        client!.cache.save();
         break;
 
       case AppLifecycleState.detached:
         break;
 
       case AppLifecycleState.resumed:
-        client.cache?.restore();
+        client!.cache.restore();
         break;
     }
   }

--- a/lib/src/widgets/graphql_consumer.dart
+++ b/lib/src/widgets/graphql_consumer.dart
@@ -3,21 +3,21 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_graphql/src/graphql_client.dart';
 import 'package:flutter_graphql/src/widgets/graphql_provider.dart';
 
-typedef Widget GraphQLConsumerBuilder(GraphQLClient client);
+typedef Widget GraphQLConsumerBuilder(GraphQLClient? client);
 
 class GraphQLConsumer extends StatelessWidget {
   const GraphQLConsumer({
-    final Key key,
-    @required this.builder,
+    final Key? key,
+    required this.builder,
     this.client,
   }) : super(key: key);
 
   final GraphQLConsumerBuilder builder;
-  final GraphQLClient client;
+  final GraphQLClient? client;
 
   @override
   Widget build(BuildContext context) {
-    GraphQLClient tmpClient;
+    GraphQLClient? tmpClient;
     if (client != null) 
       tmpClient = client;
     else

--- a/lib/src/widgets/graphql_provider.dart
+++ b/lib/src/widgets/graphql_provider.dart
@@ -13,8 +13,9 @@ class GraphQLProvider extends StatefulWidget {
   final Widget child;
 
   static ValueNotifier<GraphQLClient> of(BuildContext context) {
-    final _InheritedGraphQLProvider inheritedGraphqlProvider =
-        context.inheritFromWidgetOfExactType(_InheritedGraphQLProvider);
+    final _InheritedGraphQLProvider inheritedGraphqlProvider = context
+        .getElementForInheritedWidgetOfExactType<_InheritedGraphQLProvider>()
+        .widget;
 
     return inheritedGraphqlProvider.client;
   }

--- a/lib/src/widgets/graphql_provider.dart
+++ b/lib/src/widgets/graphql_provider.dart
@@ -4,18 +4,18 @@ import 'package:flutter_graphql/src/graphql_client.dart';
 
 class GraphQLProvider extends StatefulWidget {
   const GraphQLProvider({
-    Key key,
+    Key? key,
     this.client,
     this.child,
   }) : super(key: key);
 
-  final ValueNotifier<GraphQLClient> client;
-  final Widget child;
+  final ValueNotifier<GraphQLClient>? client;
+  final Widget? child;
 
   static ValueNotifier<GraphQLClient> of(BuildContext context) {
     final _InheritedGraphQLProvider inheritedGraphqlProvider = context
-        .getElementForInheritedWidgetOfExactType<_InheritedGraphQLProvider>()
-        .widget;
+        .getElementForInheritedWidgetOfExactType<_InheritedGraphQLProvider>()!
+        .widget as _InheritedGraphQLProvider;
 
     return inheritedGraphqlProvider.client;
   }
@@ -31,7 +31,7 @@ class _GraphQLProviderState extends State<GraphQLProvider> {
   void initState() {
     super.initState();
 
-    widget.client.addListener(didValueChange);
+    widget.client!.addListener(didValueChange);
   }
 
   @override
@@ -44,16 +44,16 @@ class _GraphQLProviderState extends State<GraphQLProvider> {
   @override
   Widget build(BuildContext context) {
     return _InheritedGraphQLProvider(
-      client: widget.client,
-      child: widget.child,
+      client: widget.client!,
+      child: widget.child!,
     );
   }
 }
 
 class _InheritedGraphQLProvider extends InheritedWidget {
   _InheritedGraphQLProvider({
-    this.client,
-    Widget child,
+    required this.client,
+    required Widget child,
   })  : clientValue = client.value,
         super(child: child);
 

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -1,67 +1,57 @@
 import 'package:flutter/widgets.dart';
-
-import 'package:flutter_graphql/src/graphql_client.dart';
+import 'package:flutter_graphql/src/cache/cache.dart';
 import 'package:flutter_graphql/src/core/observable_query.dart';
 import 'package:flutter_graphql/src/core/query_options.dart';
 import 'package:flutter_graphql/src/core/query_result.dart';
-import 'package:flutter_graphql/src/cache/cache.dart';
+import 'package:flutter_graphql/src/graphql_client.dart';
 import 'package:flutter_graphql/src/utilities/helpers.dart';
-
 import 'package:flutter_graphql/src/widgets/graphql_provider.dart';
 
 typedef RunMutation = void Function(Map<String, dynamic> variables);
 typedef MutationBuilder = Widget Function(
   RunMutation runMutation,
-  QueryResult result,
+  QueryResult? result,
 );
 
-typedef void OnMutationCompleted(QueryResult result);
-typedef void OnMutationUpdate(Cache cache, QueryResult result);
+typedef void OnMutationCompleted(QueryResult? result);
+typedef void OnMutationUpdate(Cache cache, QueryResult? result);
 
 /// Builds a [Mutation] widget based on the a given set of [MutationOptions]
 /// that streams [QueryResult]s into the [QueryBuilder].
 class Mutation extends StatefulWidget {
   const Mutation({
-    final Key key,
-    @required this.options,
-    @required this.builder,
+    final Key? key,
+    required this.options,
+    required this.builder,
     this.onCompleted,
     this.update,
   }) : super(key: key);
 
   final MutationOptions options;
   final MutationBuilder builder;
-  final OnMutationCompleted onCompleted;
-  final OnMutationUpdate update;
+  final OnMutationCompleted? onCompleted;
+  final OnMutationUpdate? update;
 
   @override
   MutationState createState() => MutationState();
 }
 
 class MutationState extends State<Mutation> {
-  GraphQLClient client;
-  ObservableQuery observableQuery;
+  GraphQLClient? client;
+  ObservableQuery? observableQuery;
 
-  WatchQueryOptions get _options => WatchQueryOptions(
-        document: widget.options.document,
-        variables: widget.options.variables,
-        fetchPolicy: widget.options.fetchPolicy,
-        errorPolicy: widget.options.errorPolicy,
-        fetchResults: false,
-        context: widget.options.context,
-        client: widget.options.client
-      );
+  WatchQueryOptions get _options => WatchQueryOptions(document: widget.options.document, variables: widget.options.variables, fetchPolicy: widget.options.fetchPolicy, errorPolicy: widget.options.errorPolicy, fetchResults: false, context: widget.options.context, client: widget.options.client);
 
   // TODO is it possible to extract shared logic into mixin
   void _initQuery() {
-    if (_options.client != null) 
-      client =_options.client;
+    if (_options.client != null)
+      client = _options.client;
     else
       client = GraphQLProvider.of(context).value;
     assert(client != null);
 
     observableQuery?.close();
-    observableQuery = client.watchQuery(_options);
+    observableQuery = client!.watchQuery(_options);
   }
 
   @override
@@ -75,17 +65,17 @@ class MutationState extends State<Mutation> {
     super.didUpdateWidget(oldWidget);
 
     // TODO @micimize - investigate why/if this was causing issues
-    if (!observableQuery.options.areEqualTo(_options)) {
+    if (!observableQuery!.options.areEqualTo(_options)) {
       _initQuery();
     }
   }
 
-  OnData get update {
+  OnData? get update {
     // fallback client in case widget has been disposed of
-    final Cache cache = client.cache;
+    final Cache cache = client!.cache;
     if (widget.update != null) {
-      void updateOnData(QueryResult result) {
-        widget.update(client?.cache ?? cache, result);
+      void updateOnData(QueryResult? result) {
+        widget.update!(client?.cache ?? cache, result);
       }
 
       return updateOnData;
@@ -93,15 +83,23 @@ class MutationState extends State<Mutation> {
     return null;
   }
 
-  Iterable<OnData> get callbacks {
-    return <OnData>[widget.onCompleted, update].where(notNull);
+  Iterable<OnData?> get callbacks {
+    return <OnData?>[
+      widget.onCompleted,
+      update
+    ].where(notNull);
   }
 
-  void runMutation(Map<String, dynamic> variables) => observableQuery
-    ..setVariables(variables)
-    ..onData(callbacks) // add callbacks to observable
-    ..sendLoading()
-    ..fetchResults();
+  void runMutation(Map<String, dynamic> variables) {
+    if (observableQuery == null) {
+      return;
+    }
+    observableQuery!
+      ..setVariables(variables)
+      ..onData(callbacks) // add callbacks to observable
+      ..sendLoading()
+      ..fetchResults();
+  }
 
   @override
   void dispose() {
@@ -111,14 +109,14 @@ class MutationState extends State<Mutation> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<QueryResult>(
+    return StreamBuilder<QueryResult?>(
       initialData: QueryResult(
         loading: false,
       ),
       stream: observableQuery?.stream,
       builder: (
         BuildContext buildContext,
-        AsyncSnapshot<QueryResult> snapshot,
+        AsyncSnapshot<QueryResult?> snapshot,
       ) {
         return widget.builder(
           runMutation,

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -7,15 +7,15 @@ import 'package:flutter_graphql/src/core/query_result.dart';
 
 import 'package:flutter_graphql/src/widgets/graphql_provider.dart';
 
-typedef QueryBuilder = Widget Function(QueryResult result);
+typedef QueryBuilder = Widget Function(QueryResult? result);
 
 /// Builds a [Query] widget based on the a given set of [QueryOptions]
 /// that streams [QueryResult]s into the [QueryBuilder].
 class Query extends StatefulWidget {
   const Query({
-    final Key key,
-    @required this.options,
-    @required this.builder,
+    final Key? key,
+    required this.options,
+    required this.builder,
   }) : super(key: key);
 
   final QueryOptions options;
@@ -26,38 +26,29 @@ class Query extends StatefulWidget {
 }
 
 class QueryState extends State<Query> {
-  ObservableQuery observableQuery;
+  ObservableQuery? observableQuery;
 
   WatchQueryOptions get _options {
-    FetchPolicy fetchPolicy = widget.options.fetchPolicy;
+    FetchPolicy? fetchPolicy = widget.options.fetchPolicy;
 
     if (fetchPolicy == FetchPolicy.cacheFirst) {
       fetchPolicy = FetchPolicy.cacheAndNetwork;
     }
 
-    return WatchQueryOptions(
-      document: widget.options.document,
-      variables: widget.options.variables,
-      fetchPolicy: fetchPolicy,
-      errorPolicy: widget.options.errorPolicy,
-      pollInterval: widget.options.pollInterval,
-      fetchResults: true,
-      context: widget.options.context,
-      client: widget.options.client
-    );
+    return WatchQueryOptions(document: widget.options.document, variables: widget.options.variables, fetchPolicy: fetchPolicy, errorPolicy: widget.options.errorPolicy, pollInterval: widget.options.pollInterval, fetchResults: true, context: widget.options.context, client: widget.options.client);
   }
 
   void _initQuery() {
-    GraphQLClient client;
+    GraphQLClient? client;
 
-    if (_options.client != null) 
-      client =_options.client;
+    if (_options.client != null)
+      client = _options.client;
     else
       client = GraphQLProvider.of(context).value;
     assert(client != null);
 
     observableQuery?.close();
-    observableQuery = client.watchQuery(_options);
+    observableQuery = client!.watchQuery(_options);
   }
 
   @override
@@ -71,7 +62,7 @@ class QueryState extends State<Query> {
     super.didUpdateWidget(oldWidget);
 
     // TODO @micimize - investigate why/if this was causing issues
-    if (!observableQuery.options.areEqualTo(_options)) {
+    if (!observableQuery!.options.areEqualTo(_options)) {
       _initQuery();
     }
   }
@@ -84,16 +75,16 @@ class QueryState extends State<Query> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<QueryResult>(
+    return StreamBuilder<QueryResult?>(
       initialData: QueryResult(
         loading: true,
       ),
-      stream: observableQuery.stream,
+      stream: observableQuery!.stream,
       builder: (
         BuildContext buildContext,
-        AsyncSnapshot<QueryResult> snapshot,
+        AsyncSnapshot<QueryResult?> snapshot,
       ) {
-        return widget?.builder(snapshot.data);
+        return widget.builder(snapshot.data);
       },
     );
   }

--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -8,9 +8,9 @@ import '../websocket/messages.dart';
 typedef OnSubscriptionCompleted = void Function();
 
 typedef SubscriptionBuilder = Widget Function({
-  final bool loading,
-  final dynamic payload,
-  final dynamic error,
+  bool loading,
+  dynamic payload,
+  dynamic error,
 });
 
 class Subscription extends StatefulWidget {

--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -8,7 +8,7 @@ import '../websocket/messages.dart';
 typedef OnSubscriptionCompleted = void Function();
 
 typedef SubscriptionBuilder = Widget Function({
-  bool loading,
+  bool? loading,
   dynamic payload,
   dynamic error,
 });
@@ -18,8 +18,8 @@ class Subscription extends StatefulWidget {
     this.operationName,
     this.query, {
     this.variables = const <String, dynamic>{},
-    final Key key,
-    @required this.builder,
+    final Key? key,
+    required this.builder,
     this.initial,
     this.onCompleted,
   }) : super(key: key);
@@ -28,7 +28,7 @@ class Subscription extends StatefulWidget {
   final String query;
   final dynamic variables;
   final SubscriptionBuilder builder;
-  final OnSubscriptionCompleted onCompleted;
+  final OnSubscriptionCompleted? onCompleted;
   final dynamic initial;
 
   @override
@@ -89,7 +89,7 @@ class _SubscriptionState extends State<Subscription> {
 
   void _onDone() {
     if (widget.onCompleted != null) {
-      widget.onCompleted();
+      widget.onCompleted!();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.1.1-dev.2
+version: 1.1.2-dev.3
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.17.10
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   meta: ^1.1.6
   http: ^0.12.0
   http_parser: ^3.1.3
-  path_provider: ^0.5.0+1
+  path_provider: ^1.1.0
   uuid: ^2.0.0
   sqflite: ^1.1.0
   graphql_parser: ^1.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.0.0-rc.3
+version: 1.0.1
 authors:
   - Rex Raphael <rex.raphael@outlook.com>
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
@@ -9,11 +9,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.6
-  http: ^0.12.0
-  http_parser: ^3.1.3
-  path_provider: ^1.1.0
-  uuid: ^2.0.0
-  sqflite: ^1.1.0
+  http: ^0.13.1
+  http_parser: ^4.0.0
+  path_provider: ^2.0.1
+  uuid: ^3.0.3
+  sqflite: ^2.0.0+3
   graphql_parser: ^1.1.1
 
 dev_dependencies:
@@ -22,4 +22,4 @@ dev_dependencies:
   test: ^1.3.0
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.1.3-dev.4
+version: 1.1.4-dev.5
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.0.1
-authors:
-  - Rex Raphael <rex.raphael@outlook.com>
+version: 1.1.0-dev.1
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 
 dependencies:
@@ -14,7 +12,8 @@ dependencies:
   path_provider: ^2.0.1
   uuid: ^3.0.3
   sqflite: ^2.0.0+3
-  graphql_parser: ^1.1.1
+  graphql_parser2: ^2.1.0
+  collection: ^1.15.0-nullsafety.4
 
 dev_dependencies:
   flutter_test:
@@ -22,4 +21,4 @@ dev_dependencies:
   test: ^1.3.0
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.1.0-dev.1
+version: 1.1.1-dev.2
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_graphql
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 1.1.2-dev.3
+version: 1.1.3-dev.4
 homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,19 +6,17 @@ homepage: https://github.com/snowballdigital/graphql-flutter/tree/master
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.6
-  http: ^0.13.1
+  http: ^0.13.4
   http_parser: ^4.0.0
-  path_provider: ^2.0.1
-  uuid: ^3.0.3
-  sqflite: ^2.0.0+3
+  path_provider: ^2.0.5
+  uuid: ^3.0.5
+  sqflite: ^2.0.0+4
   graphql_parser2: ^2.1.0
-  collection: ^1.15.0-nullsafety.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.3.0
+  test: ^1.17.10
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
   test: ^1.3.0
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.5.0 <3.0.0"

--- a/test/normalized_in_memory_test.dart
+++ b/test/normalized_in_memory_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:flutter_graphql/src/cache/normalized_in_memory.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 List<String> reference(String key) {
   return <String>['cache/reference', key];


### PR DESCRIPTION
On Flutter 1.5.4 (current stable), this is breaking with the following message:

```
Function-typed parameters can't specify 'const', 'final' or 'var' in place of a return type.
Try replacing the keyword with a return type.dart(function_typed_parameter_var)
```

### Breaking changes

NONE

#### Fixes / Enhancements

- Fixed by removing the `final` keyword.
